### PR TITLE
Limit CI push trigger to master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Avoid duplicate CI runs on same-repo pull requests by limiting push-triggered CI to master while keeping pull request validation for master.

## Validation

- Parsed .github/workflows/test.yml locally with Ruby YAML