### PR TITLE
Modernize NumPy and SciPy compatibility

### DIFF
--- a/acoustics/_signal.py
+++ b/acoustics/_signal.py
@@ -37,8 +37,8 @@ class Signal(np.ndarray):
         else:
             return array
 
-    def __array_wrap__(self, out_arr, context=None):
-        return np.ndarray.__array_wrap__(self, out_arr, context)
+    def __array_wrap__(self, out_arr, context=None, return_scalar=False):
+        return np.ndarray.__array_wrap__(self, out_arr, context, return_scalar)
 
     def __array_finalize__(self, obj):
         # see InfoArray.__array_finalize__ for comments

--- a/acoustics/bands.py
+++ b/acoustics/bands.py
@@ -129,14 +129,14 @@ def _check_band_type(freqs):
     third_oct_bands = third(12.5, 20000)
 
     def _check_sort(freqs, bands):
-        index = np.where(np.in1d(bands, freqs))[0]
+        index = np.where(np.isin(bands, freqs))[0]
         band_pos = index - index[0]
         return (band_pos == np.arange(band_pos.size)).all()
 
-    if np.in1d(freqs, octave_bands).all():
+    if np.isin(freqs, octave_bands).all():
         is_sorted = _check_sort(freqs, octave_bands)
         band_type = "octave" if is_sorted else "octave-unsorted"
-    elif np.in1d(freqs, third_oct_bands).all():
+    elif np.isin(freqs, third_oct_bands).all():
         is_sorted = _check_sort(freqs, third_oct_bands)
         band_type = "third" if is_sorted else "third-unsorted"
     else:

--- a/acoustics/directivity.py
+++ b/acoustics/directivity.py
@@ -18,7 +18,7 @@ from matplotlib.colors import Normalize
 from mpl_toolkits.mplot3d import Axes3D
 import numpy as np
 from scipy.interpolate import interp2d as interpolate
-from scipy.special import sph_harm  # pylint: disable=no-name-in-module
+from scipy.special import sph_harm_y  # pylint: disable=no-name-in-module
 
 
 def cardioid(theta, a=1.0, k=1.0):
@@ -47,10 +47,10 @@ def spherical_harmonic(theta, phi, m=0, n=0):
 
     .. note:: The degree `n` is often denoted `l`.
 
-    .. seealso:: :func:`scipy.special.sph_harm`
+    .. seealso:: :func:`scipy.special.sph_harm_y`
 
     """
-    return sph_harm(m, n, phi, theta).real
+    return sph_harm_y(n, m, theta, phi).real
 
 
 def spherical_to_cartesian(r, theta, phi):

--- a/acoustics/signal.py
+++ b/acoustics/signal.py
@@ -754,7 +754,10 @@ def bandpass_frequencies(x, fs, frequencies, order=8, purge=False, zero_phase=Fa
     if purge:
         frequencies = frequencies[frequencies.upper < fs / 2.0]
     return frequencies, np.array(
-        [bandpass(x, band.lower, band.upper, fs, order, zero_phase=zero_phase) for band in frequencies]
+        [
+            bandpass(x, lower, upper, fs, order, zero_phase=zero_phase)
+            for lower, upper in zip(frequencies.lower, frequencies.upper)
+        ]
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,16 +23,16 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "numpy >= 1.22, < 2.4",
-    "scipy >= 1.8, < 1.16",
-    "matplotlib >= 3.5",
-    "pandas >= 1.4",
-    "tabulate >= 0.9",
-    "soundfile >= 0.12.1",
+    "numpy >= 2.0, < 3.0",
+    "scipy >= 1.15, < 2.0",
+    "matplotlib >= 3.8",
+    "pandas >= 2.2",
+    "tabulate >= 0.10",
+    "soundfile >= 0.13.1",
 ]
 [project.optional-dependencies]
 fast_fft = [
-    "pyFFTW >= 0.13"
+    "pyFFTW >= 0.15"
 ]
 [project.license]
 file = "LICENSE"

--- a/tests/test_directivity.py
+++ b/tests/test_directivity.py
@@ -15,3 +15,9 @@ import pytest
 )
 def test_figure_eight(given, expected, uncertainty):
     assert figure_eight(given) == pytest.approx(expected, uncertainty)
+
+
+def test_spherical_harmonic_theta_phi_convention():
+    assert spherical_harmonic(0.0, 0.0, m=0, n=0) == pytest.approx(1.0 / (2.0 * np.sqrt(np.pi)))
+    assert spherical_harmonic(0.0, 0.0, m=0, n=1) == pytest.approx(np.sqrt(3.0 / (4.0 * np.pi)))
+    assert spherical_harmonic(np.pi / 2.0, 0.0, m=0, n=1) == pytest.approx(0.0)

--- a/uv.lock
+++ b/uv.lock
@@ -61,13 +61,13 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "matplotlib", specifier = ">=3.5" },
-    { name = "numpy", specifier = ">=1.22,<2.4" },
-    { name = "pandas", specifier = ">=1.4" },
-    { name = "pyfftw", marker = "extra == 'fast-fft'", specifier = ">=0.13" },
-    { name = "scipy", specifier = ">=1.8,<1.16" },
-    { name = "soundfile", specifier = ">=0.12.1" },
-    { name = "tabulate", specifier = ">=0.9" },
+    { name = "matplotlib", specifier = ">=3.8" },
+    { name = "numpy", specifier = ">=2.0,<3.0" },
+    { name = "pandas", specifier = ">=2.2" },
+    { name = "pyfftw", marker = "extra == 'fast-fft'", specifier = ">=0.15" },
+    { name = "scipy", specifier = ">=1.15,<2.0" },
+    { name = "soundfile", specifier = ">=0.13.1" },
+    { name = "tabulate", specifier = ">=0.10" },
 ]
 provides-extras = ["fast-fft"]
 


### PR DESCRIPTION
## Summary

- Require modern scientific Python dependency floors, including NumPy 2.x and SciPy 1.15+.
- Update the Signal ndarray hook for NumPy 2.x `__array_wrap__` semantics.
- Replace deprecated `np.in1d` calls with `np.isin`.
- Use `scipy.special.sph_harm_y` instead of the deprecated spherical harmonics API.
- Avoid one-band wrapper allocation when filtering octave-band frequencies.
- Add a regression test for the public spherical harmonic angle convention.

This keeps the package version at 0.3.0; version bumps stay part of explicit release prep.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -q`
- `uv build`
