### PR TITLE
Fix wvd() bugs and add chirp tests

### DIFF
--- a/acoustics/signal.py
+++ b/acoustics/signal.py
@@ -1088,43 +1088,46 @@ def instantaneous_frequency(signal, fs, axis=-1):
 
 
 def wvd(signal, fs, analytic=True):
-    """Wigner-Ville Distribution
+    """Wigner-Ville Distribution.
 
     :param signal: Signal
     :param fs: Sample frequency
     :param analytic: Use the analytic signal, calculated using Hilbert transform.
+    :returns: Tuple ``(f, W)`` where ``f`` is the frequency axis (length
+        ``N``, Nyquist ``fs / 4`` when ``analytic`` is True) and ``W`` has
+        shape ``(N, len(signal))`` with rows indexed by ``f`` and columns
+        by time.
 
     .. math:: W_z(n, \\omega) = 2 \\sum_k z^*[n-k]z[n+k] e^{-j\\omega 2kT}
 
-    Includes positive and negative frequencies.
+    The factor ``2kT`` in the exponent halves the effective Nyquist
+    frequency, so for a complex tone at :math:`f_0` the peak appears at
+    bin :math:`f_0`. The returned frequency axis accounts for this.
 
     """
     signal = np.asarray(signal)
 
     N = int(len(signal) + len(signal) % 2)
-    length_FFT = N  # Take an even value of N
-
-    # if N != len(signal):
-    #    signal = np.concatenate(signal, [0])
-
+    length_FFT = N
     length_time = len(signal)
 
     if analytic:
         signal = hilbert(signal)
     s = np.concatenate((np.zeros(length_time), signal, np.zeros(length_time)))
-    W = np.zeros((length_FFT, length_time))
-    tau = np.arange(0, N // 2)
 
-    R = np.zeros((N, length_time), dtype='float64')
+    tau = np.arange(0, N // 2)
+    tau_mirror = np.arange(1, N // 2)
+
+    R = np.zeros((N, length_time), dtype=np.complex128)
 
     i = length_time
     for t in range(length_time):
-        R[t, tau] = s[i + tau] * s[i - tau].conj()  # In one direction
-        R[t, N - (tau + 1)] = R[t, tau + 1].conj()  # And the other direction
+        R[t, tau] = s[i + tau] * s[i - tau].conj()
+        R[t, N - tau_mirror] = R[t, tau_mirror].conj()
         i += 1
     W = np.fft.fft(R, length_FFT) / (2 * length_FFT)
 
-    f = np.fft.fftfreq(N, 1.0 / fs)
+    f = np.fft.fftfreq(N, 2.0 / fs)
     return f, W.T
 
 

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -279,6 +279,59 @@ def ob(fraction):
     return OctaveBand(fstart=10.0, fstop=1000, fraction=fraction)
 
 
+class TestWvd:
+    """Tests for :func:`acoustics.signal.wvd`."""
+
+    def test_tone_peak_tracks_frequency(self):
+        """A complex tone's WVD should peak at its frequency at every time."""
+        fs = 1000.0
+        duration = 1.0
+        t = np.arange(0, duration, 1 / fs)
+        f0 = 100.0
+        z = np.exp(2j * np.pi * f0 * t)
+
+        f, W = wvd(z, fs, analytic=False)
+
+        # Ignore the zero-padded edges of the autocorrelation.
+        interior = slice(len(t) // 4, 3 * len(t) // 4)
+        peaks = f[np.argmax(np.abs(W[:, interior]), axis=0)]
+        np.testing.assert_allclose(peaks, f0, atol=fs / len(t))
+
+    def test_chirp_peak_tracks_instantaneous_frequency(self):
+        """Peak frequency of a linear chirp's WVD tracks f(t) = f0 + a*t."""
+        fs = 1000.0
+        duration = 1.0
+        t = np.arange(0, duration, 1 / fs)
+        f0, f1 = 50.0, 200.0
+        rate = (f1 - f0) / duration
+        x = np.cos(2 * np.pi * (f0 * t + 0.5 * rate * t**2))
+
+        f, W = wvd(x, fs, analytic=True)
+
+        interior = (t > 0.1) & (t < 0.9)
+        instantaneous = f0 + rate * t
+        peaks = f[np.argmax(np.abs(W[:, interior]), axis=0)]
+        rms_error = np.sqrt(np.mean((peaks - instantaneous[interior]) ** 2))
+        # Bin spacing is fs / (2 * N) ≈ 0.5 Hz; allow a few bins of tolerance.
+        assert rms_error < 2.0
+
+    def test_frequency_axis_is_quarter_nyquist(self):
+        """Analytic WVD Nyquist is fs/4 because of the 2kT factor in the kernel."""
+        fs = 2000.0
+        x = np.zeros(128)
+        f, _ = wvd(x, fs)
+        assert f.max() == pytest.approx(fs / 4.0, rel=0, abs=fs / (2 * len(x)))
+        assert f.min() == pytest.approx(-fs / 4.0, rel=0, abs=fs / (2 * len(x)))
+
+    def test_output_is_real(self):
+        """The Wigner-Ville distribution is mathematically real-valued."""
+        fs = 500.0
+        t = np.arange(0, 0.5, 1 / fs)
+        x = np.cos(2 * np.pi * 80 * t)
+        _, W = wvd(x, fs)
+        np.testing.assert_allclose(W.imag, 0, atol=1e-10)
+
+
 class TestOctaveBand:
     def test_unique(self, ob):
         """Test whether we don't have duplicate values."""


### PR DESCRIPTION
Test the Wigner-Ville distribution against a pure tone and a linear chirp. Fix three bugs surfaced by those tests:

- R was allocated as float64 so complex values from the analytic autocorrelation were silently cast to real (ComplexWarning on every call). Use complex128 so the autocorrelation survives.
- The mirror loop assigned R[t, N - (tau + 1)] = R[t, tau + 1].conj() for tau in [0, N/2), which overwrote the Nyquist bin with conj(self) instead of leaving it zero and skipped tau = 0. Iterate tau over [1, N/2) so the positive and negative lag halves meet at the Nyquist bin without touching it.
- The returned frequency axis used fftfreq(N, 1/fs), which put the peak of a tone at 2*f0 because the 2kT factor in the exponent of the WVD kernel halves the effective Nyquist. Use fftfreq(N, 2/fs) so a tone at f0 peaks at f0.